### PR TITLE
Assistant API

### DIFF
--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
@@ -14,22 +14,22 @@ import java.util.UUID
 
 object JsonFormats {
   // vector-stuff formats
-  implicit val namespaceStatsFormat: Format[NamespaceStats] = Json.format[NamespaceStats]
-  implicit val indexStatsFormat: Format[IndexStats] = Json.format[IndexStats]
-  implicit val sparseVectorFormat: Format[SparseVector] = Json.format[SparseVector]
-  implicit val vectorFormat: Format[PVector] = Json.format[PVector]
-  implicit val matchFormat: Format[Match] = Json.format[Match]
-  implicit val queryResultFormat: Format[QueryResponse] = Json.format[QueryResponse]
-  implicit val fetchResponseFormat: Format[FetchResponse] = Json.format[FetchResponse]
-  implicit val vectorIdFormat: Format[VectorId] = Json.format[VectorId]
-  implicit val listVectorIdsPaginationFormat: Format[ListVectorIdsPagination] =
+  implicit lazy val namespaceStatsFormat: Format[NamespaceStats] = Json.format[NamespaceStats]
+  implicit lazy val indexStatsFormat: Format[IndexStats] = Json.format[IndexStats]
+  implicit lazy val sparseVectorFormat: Format[SparseVector] = Json.format[SparseVector]
+  implicit lazy val vectorFormat: Format[PVector] = Json.format[PVector]
+  implicit lazy val matchFormat: Format[Match] = Json.format[Match]
+  implicit lazy val queryResultFormat: Format[QueryResponse] = Json.format[QueryResponse]
+  implicit lazy val fetchResponseFormat: Format[FetchResponse] = Json.format[FetchResponse]
+  implicit lazy val vectorIdFormat: Format[VectorId] = Json.format[VectorId]
+  implicit lazy val listVectorIdsPaginationFormat: Format[ListVectorIdsPagination] =
     Json.format[ListVectorIdsPagination]
-  implicit val listVectorIdsResponseFormat: Format[ListVectorIdsResponse] =
+  implicit lazy val listVectorIdsResponseFormat: Format[ListVectorIdsResponse] =
     Json.format[ListVectorIdsResponse]
 
   // index/collection formats
-  implicit val collectionInfoFormat: Format[CollectionInfo] = Json.format[CollectionInfo]
-  implicit val indexStatusFormat: Format[IndexStatus] = {
+  implicit lazy val collectionInfoFormat: Format[CollectionInfo] = Json.format[CollectionInfo]
+  implicit lazy val indexStatusFormat: Format[IndexStatus] = {
     import IndexStatus._
     enumFormat[IndexStatus](
       Initializing,
@@ -40,7 +40,7 @@ object JsonFormats {
       InitializationFailed
     )
   }
-  implicit val podTypeFormat: Format[PodType] = {
+  implicit lazy val podTypeFormat: Format[PodType] = {
     import PodType._
     enumFormat[PodType](
       s1_x1,
@@ -57,7 +57,7 @@ object JsonFormats {
       p2_x8
     )
   }
-  implicit val metricFormat: Format[Metric] = {
+  implicit lazy val metricFormat: Format[Metric] = {
     import Metric._
     enumFormat[Metric](
       euclidean,
@@ -67,50 +67,50 @@ object JsonFormats {
   }
 
   // pod-based
-  implicit val indexConfigFormat: Format[PodBasedIndexConfig] =
+  implicit lazy val indexConfigFormat: Format[PodBasedIndexConfig] =
     Json.format[PodBasedIndexConfig]
-  implicit val indexDatabaseInfoFormat: Format[PodBasedIndexDatabaseInfo] =
+  implicit lazy val indexDatabaseInfoFormat: Format[PodBasedIndexDatabaseInfo] =
     Json.format[PodBasedIndexDatabaseInfo]
-  implicit val indexStatusInfoFormat: Format[PodBasedIndexStatusInfo] =
+  implicit lazy val indexStatusInfoFormat: Format[PodBasedIndexStatusInfo] =
     Json.format[PodBasedIndexStatusInfo]
-  implicit val indexInfoFormat: Format[PodBasedIndexInfo] = Json.format[PodBasedIndexInfo]
+  implicit lazy val indexInfoFormat: Format[PodBasedIndexInfo] = Json.format[PodBasedIndexInfo]
 
   // serverless
-  implicit val serverlessIndexStatusFormat: Format[ServerlessIndexStatus] =
+  implicit lazy val serverlessIndexStatusFormat: Format[ServerlessIndexStatus] =
     Json.format[ServerlessIndexStatus]
-  implicit val serverlessIndexSpecAuxFormat: Format[ServerlessIndexSpecAux] =
+  implicit lazy val serverlessIndexSpecAuxFormat: Format[ServerlessIndexSpecAux] =
     Json.format[ServerlessIndexSpecAux]
-  implicit val serverlessIndexSpecFormat: Format[ServerlessIndexSpec] =
+  implicit lazy val serverlessIndexSpecFormat: Format[ServerlessIndexSpec] =
     Json.format[ServerlessIndexSpec]
-  implicit val serverlessIndexInfoFormat: Format[ServerlessIndexInfo] =
+  implicit lazy val serverlessIndexInfoFormat: Format[ServerlessIndexInfo] =
     Json.format[ServerlessIndexInfo]
 
   // embeddings
-  implicit val embeddingUsageInfoReads: Reads[EmbeddingsUsageInfo] =
+  implicit lazy val embeddingUsageInfoReads: Reads[EmbeddingsUsageInfo] =
     Json.reads[EmbeddingsUsageInfo]
-  implicit val embeddingInfoReads: Reads[EmbeddingsInfo] = Json.reads[EmbeddingsInfo]
-  implicit val embeddingValuesReads: Reads[EmbeddingsValues] = Json.reads[EmbeddingsValues]
-  implicit val embeddingResponseReads: Reads[GenerateEmbeddingsResponse] =
+  implicit lazy val embeddingInfoReads: Reads[EmbeddingsInfo] = Json.reads[EmbeddingsInfo]
+  implicit lazy val embeddingValuesReads: Reads[EmbeddingsValues] = Json.reads[EmbeddingsValues]
+  implicit lazy val embeddingResponseReads: Reads[GenerateEmbeddingsResponse] =
     Json.reads[GenerateEmbeddingsResponse]
 
-  implicit val embeddingsInputTypeWrites: Writes[EmbeddingsInputType] = enumFormat(
+  implicit lazy val embeddingsInputTypeWrites: Writes[EmbeddingsInputType] = enumFormat(
     Query,
     Passage
   )
 
-  implicit val embeddingsTruncateWrites: Writes[EmbeddingsTruncate] = enumFormat(
+  implicit lazy val embeddingsTruncateWrites: Writes[EmbeddingsTruncate] = enumFormat(
     EmbeddingsTruncate.None,
     EmbeddingsTruncate.End
   )
 
   // assistants
-  implicit val assistantStatusFormat: Format[Assistant.Status] = enumFormat(
+  implicit lazy val assistantStatusFormat: Format[Assistant.Status] = enumFormat(
     Assistant.Status.Initializing,
     Assistant.Status.Failed,
     Assistant.Status.Ready,
     Assistant.Status.Terminating
   )
-  implicit val assistantFormat: Format[Assistant] = {
+  implicit lazy val assistantFormat: Format[Assistant] = {
     val reads: Reads[Assistant] = (
       (__ \ "name").read[String] and
         (__ \ "metadata").readWithDefault[Map[String, String]](Map.empty[String, String]) and
@@ -123,17 +123,17 @@ object JsonFormats {
     Format(reads, writes)
   }
 
-  implicit val listAssistantsResponseFormat: Format[ListAssistantsResponse] =
+  implicit lazy val listAssistantsResponseFormat: Format[ListAssistantsResponse] =
     Json.format[ListAssistantsResponse]
 
   // files
-  implicit val fileStatusFormat: Format[FileResponse.Status] = enumFormat(
+  implicit lazy val fileStatusFormat: Format[FileResponse.Status] = enumFormat(
     FileResponse.Status.Deleting,
     FileResponse.Status.Available,
     FileResponse.Status.Processing,
     FileResponse.Status.ProcessingFailed
   )
-  implicit val fileFormat: Format[FileResponse] = {
+  implicit lazy val fileFormat: Format[FileResponse] = {
     val reads: Reads[FileResponse] = (
       (__ \ "name").read[String] and
         (__ \ "id").read[UUID] and
@@ -147,17 +147,25 @@ object JsonFormats {
     Format(reads, writes)
   }
 
-  implicit val listFilesResponseFormat: Format[ListFilesResponse] =
+  implicit lazy val listFilesResponseFormat: Format[ListFilesResponse] =
     Json.format[ListFilesResponse]
 
   // chat
-  implicit val chatCompletionMessageFormat: Format[ChatCompletionMessage] =
+  implicit lazy val userMessagesFormat: Writes[UserMessage] =
+    Writes[UserMessage] { userMessage =>
+      Json.obj(
+        "role" -> "user",
+        "content" -> userMessage.content
+      )
+    }
+
+  implicit lazy val chatCompletionMessageFormat: Format[ChatCompletionMessage] =
     Json.format[ChatCompletionMessage]
-  implicit val chatCompletionChoiceRoleFormat: Format[Choice.Role] = enumFormat(
+  implicit lazy val chatCompletionChoiceRoleFormat: Format[Choice.Role] = enumFormat(
     Choice.Role.user,
     Choice.Role.assistant
   )
-  implicit val chatCompletionChoiceFinishReasonFormat: Format[Choice.FinishReason] =
+  implicit lazy val chatCompletionChoiceFinishReasonFormat: Format[Choice.FinishReason] =
     enumFormat(
       Choice.FinishReason.Stop,
       Choice.FinishReason.Length,
@@ -165,7 +173,7 @@ object JsonFormats {
       Choice.FinishReason.ContentFilter,
       Choice.FinishReason.FunctionCall
     )
-  implicit val chatCompletionChoiceFormat: Format[Choice] = Json.format[Choice]
-  implicit val chatCompletionModelFormat: Format[ChatCompletionResponse] =
+  implicit lazy val chatCompletionChoiceFormat: Format[Choice] = Json.format[Choice]
+  implicit lazy val chatCompletionModelFormat: Format[ChatCompletionResponse] =
     Json.format[ChatCompletionResponse]
 }

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
@@ -1,5 +1,6 @@
 package io.cequence.pineconescala
 
+import io.cequence.pineconescala.domain.response.Choice.ChatCompletionMessage
 import io.cequence.pineconescala.domain.response._
 import io.cequence.pineconescala.domain.settings.{EmbeddingsInputType, EmbeddingsTruncate}
 import io.cequence.pineconescala.domain.settings.EmbeddingsInputType.{Passage, Query}
@@ -114,4 +115,20 @@ object JsonFormats {
     File.Status.ProcessingFailed,
   )
   implicit val fileFormat: Format[File] = Json.format[File]
+
+  // chat
+  implicit val chatCompletionMessageFormat: Format[ChatCompletionMessage] = Json.format[ChatCompletionMessage]
+  implicit val chatCompletionChoiceRoleFormat: Format[Choice.Role] = enumFormat(
+    Choice.Role.user,
+    Choice.Role.assistant
+  )
+  implicit val chatCompletionChoiceFinishReasonFormat: Format[Choice.FinishReason] = enumFormat(
+    Choice.FinishReason.Stop,
+    Choice.FinishReason.Length,
+    Choice.FinishReason.ToolCalls,
+    Choice.FinishReason.ContentFilter,
+    Choice.FinishReason.FunctionCall
+  )
+  implicit val chatCompletionChoiceFormat: Format[Choice] = Json.format[Choice]
+  implicit val chatCompletionModelFormat: Format[ChatCompletionResponse] = Json.format[ChatCompletionResponse]
 }

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
@@ -106,5 +106,12 @@ object JsonFormats {
   )
   implicit val assistantFormat: Format[Assistant] = Json.format[Assistant]
 
-
+  // files
+  implicit val fileStatusFormat: Format[File.Status] = enumFormat(
+    File.Status.Deleting,
+    File.Status.Available,
+    File.Status.Processing,
+    File.Status.ProcessingFailed,
+  )
+  implicit val fileFormat: Format[File] = Json.format[File]
 }

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
@@ -96,4 +96,15 @@ object JsonFormats {
     EmbeddingsTruncate.None,
     EmbeddingsTruncate.End
   )
+
+  // assistants
+  implicit val assistantStatusFormat: Format[Assistant.Status] = enumFormat(
+    Assistant.Status.Initializing,
+    Assistant.Status.Failed,
+    Assistant.Status.Ready,
+    Assistant.Status.Terminating,
+  )
+  implicit val assistantFormat: Format[Assistant] = Json.format[Assistant]
+
+
 }

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
@@ -116,6 +116,7 @@ object JsonFormats {
     File.Status.ProcessingFailed,
   )
   implicit val fileFormat: Format[File] = Json.format[File]
+  implicit val listFilesResponseFormat: Format[ListFilesResponse] = Json.format[ListFilesResponse]
 
   // chat
   implicit val chatCompletionMessageFormat: Format[ChatCompletionMessage] = Json.format[ChatCompletionMessage]

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
@@ -106,6 +106,7 @@ object JsonFormats {
     Assistant.Status.Terminating,
   )
   implicit val assistantFormat: Format[Assistant] = Json.format[Assistant]
+  implicit val listAssistantsResponseFormat: Format[ListAssistantsResponse] = Json.format[ListAssistantsResponse]
 
   // files
   implicit val fileStatusFormat: Format[File.Status] = enumFormat(

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/JsonFormats.scala
@@ -109,13 +109,13 @@ object JsonFormats {
   implicit val listAssistantsResponseFormat: Format[ListAssistantsResponse] = Json.format[ListAssistantsResponse]
 
   // files
-  implicit val fileStatusFormat: Format[File.Status] = enumFormat(
-    File.Status.Deleting,
-    File.Status.Available,
-    File.Status.Processing,
-    File.Status.ProcessingFailed,
+  implicit val fileStatusFormat: Format[FileResponse.Status] = enumFormat(
+    FileResponse.Status.Deleting,
+    FileResponse.Status.Available,
+    FileResponse.Status.Processing,
+    FileResponse.Status.ProcessingFailed,
   )
-  implicit val fileFormat: Format[File] = Json.format[File]
+  implicit val fileFormat: Format[FileResponse] = Json.format[FileResponse]
   implicit val listFilesResponseFormat: Format[ListFilesResponse] = Json.format[ListFilesResponse]
 
   // chat

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/EndPoint.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/EndPoint.scala
@@ -9,6 +9,7 @@ object EndPoint {
   case object assistants extends EndPoint("assistant/assistants")
   case object describe_index_stats extends EndPoint
   case object embed extends EndPoint
+  case object files extends EndPoint("assistant/files")
   case object query extends EndPoint
   case object vectors_delete extends EndPoint("vectors/delete")
   case object vectors_fetch extends EndPoint("vectors/fetch")

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/EndPoint.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/EndPoint.scala
@@ -7,6 +7,7 @@ sealed abstract class EndPoint(value: String = "") extends NamedEnumValue(value)
 
 object EndPoint {
   case object assistants extends EndPoint("assistant/assistants")
+  case object chat extends EndPoint("assistant/chat")
   case object describe_index_stats extends EndPoint
   case object embed extends EndPoint
   case object files extends EndPoint("assistant/files")
@@ -60,6 +61,7 @@ object Tag {
   case object model extends Tag
   case object parameters extends Tag
   case object metadata extends Tag
+  case object messages extends Tag
 
   // TODO: move elsewhere
   def fromCreatePodBasedIndexSettings(

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/EndPoint.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/EndPoint.scala
@@ -58,6 +58,7 @@ object Tag {
   case object inputs extends Tag
   case object model extends Tag
   case object parameters extends Tag
+  case object metadata extends Tag
 
   // TODO: move elsewhere
   def fromCreatePodBasedIndexSettings(

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/EndPoint.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/EndPoint.scala
@@ -6,6 +6,7 @@ import io.cequence.wsclient.domain.NamedEnumValue
 sealed abstract class EndPoint(value: String = "") extends NamedEnumValue(value)
 
 object EndPoint {
+  case object assistants extends EndPoint("assistant/assistants")
   case object describe_index_stats extends EndPoint
   case object embed extends EndPoint
   case object query extends EndPoint

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/EndPoint.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/EndPoint.scala
@@ -62,6 +62,7 @@ object Tag {
   case object parameters extends Tag
   case object metadata extends Tag
   case object messages extends Tag
+  case object file extends Tag
 
   // TODO: move elsewhere
   def fromCreatePodBasedIndexSettings(

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantFileServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantFileServiceImpl.scala
@@ -1,0 +1,115 @@
+package io.cequence.pineconescala.service
+
+import akka.stream.Materializer
+import com.typesafe.config.Config
+import io.cequence.pineconescala.PineconeScalaClientException
+import io.cequence.pineconescala.domain.response.{DeleteResponse, File, ListFilesResponse}
+import io.cequence.wsclient.ResponseImplicits.JsonSafeOps
+import io.cequence.wsclient.domain.{RichResponse, WsRequestContext}
+import io.cequence.wsclient.service.ws.{Timeouts, WSRequestHelper}
+import io.cequence.pineconescala.JsonFormats._
+
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
+
+class PineconeAssistantFileServiceImpl(
+  apiKey: String,
+  explicitTimeouts: Option[Timeouts] = None
+)(
+  implicit val ec: ExecutionContext,
+  val materializer: Materializer
+) extends PineconeAssistantFileService
+    with WSRequestHelper {
+
+  override protected type PEP = EndPoint
+  override protected type PT = Tag
+  override val coreUrl: String = "https://prod-1-data.ke.pinecone.io/"
+  override protected val requestContext = WsRequestContext(
+    authHeaders = Seq(
+      ("Api-Key", apiKey)
+      // ("X-Pinecone-API-Version", "2024-07")
+    ),
+    explTimeouts = explicitTimeouts
+  )
+
+  override def listFiles(assistantName: String): Future[Seq[File]] =
+    execGET(EndPoint.files, endPointParam = Some(assistantName))
+      .map(_.asSafeJson[ListFilesResponse])
+      .map(_.files)
+
+  override def uploadFile(assistantName: String): Future[File] = {
+    // TODO: file contents
+    execPOST(
+      EndPoint.files,
+      endPointParam = Some(assistantName)
+    ).map(_.asSafeJson[File])
+  }
+
+  override def describeFile(
+    assistantName: String,
+    fileId: UUID
+  ): Future[Option[File]] =
+    execGETRich(
+      EndPoint.files,
+      // FIXME: provide support for multiple end point params
+      endPointParam = Some(s"$assistantName/${fileId.toString}")
+    ).map { response =>
+      handleNotFoundAndError(response).map(
+        _.asSafeJson[File]
+      )
+    }
+
+  override def deleteFile(
+    assistantName: String,
+    fileId: UUID
+  ): Future[DeleteResponse] =
+    execDELETERich(
+      EndPoint.files,
+      endPointParam = Some(s"$assistantName/${fileId.toString}")
+    ).map(handleDeleteResponse)
+
+  override protected def handleErrorCodes(
+    httpCode: Int,
+    message: String
+  ): Nothing =
+    throw new PineconeScalaClientException(s"Code ${httpCode} : ${message}")
+
+  protected def handleDeleteResponse(response: RichResponse): DeleteResponse =
+    response.status.code match {
+      case 200 => DeleteResponse.Deleted
+      case 404 => DeleteResponse.NotFound
+      case _ =>
+        throw new PineconeScalaClientException(
+          s"Code ${response.status.code} : ${response.status.message}"
+        )
+    }
+
+}
+
+object PineconeAssistantFileServiceFactory extends PineconeServiceFactoryHelper {
+
+  def apply(
+    apiKey: String,
+    timeouts: Option[Timeouts] = None
+  )(
+    implicit ec: ExecutionContext,
+    materializer: Materializer
+  ): PineconeAssistantFileService = {
+    new PineconeAssistantFileServiceImpl(apiKey, timeouts)
+  }
+
+  def apply(
+    config: Config
+  )(
+    implicit ec: ExecutionContext,
+    materializer: Materializer
+  ): PineconeAssistantFileService = {
+    val timeouts = loadTimeouts(config)
+
+    apply(
+      apiKey = config.getString(s"$configPrefix.apiKey"),
+      timeouts = timeouts.toOption
+    )
+  }
+
+}

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -2,7 +2,7 @@ package io.cequence.pineconescala.service
 
 import akka.stream.Materializer
 import com.typesafe.config.Config
-import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, ListAssistantsResponse, ListFilesResponse}
+import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, ListAssistantsResponse, ListFilesResponse, UserMessage}
 import io.cequence.wsclient.domain.{RichResponse, WsRequestContext}
 import io.cequence.wsclient.service.ws.{Timeouts, WSRequestHelper}
 import io.cequence.pineconescala.JsonFormats._
@@ -63,15 +63,6 @@ class PineconeAssistantServiceImpl(
       EndPoint.assistants,
       endPointParam = Some(name)
     ).map(handleDeleteResponse)
-
-  override def chatWithAssistant(assistantName: String, messages: Seq[String]): Future[ChatCompletionResponse] =
-    execPOST(
-      EndPoint.chat,
-      // FIXME: provide support for end point param followed by URL suffix
-      endPointParam = Some(s"$assistantName/chat/completions"),
-      bodyParams = jsonBodyParams(
-        Tag.messages -> Some(messages.map(Json.toJson(_))))
-    ).map(_.asSafeJson[ChatCompletionResponse])
 
   override protected def handleErrorCodes(
     httpCode: Int,

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -1,0 +1,77 @@
+package io.cequence.pineconescala.service
+
+import akka.stream.Materializer
+import com.typesafe.config.Config
+import io.cequence.pineconescala.domain.response.Assistant
+import io.cequence.wsclient.domain.WsRequestContext
+import io.cequence.wsclient.service.ws.{Timeouts, WSRequestHelper}
+import play.api.libs.ws.StandaloneWSRequest
+import io.cequence.pineconescala.JsonFormats._
+import io.cequence.pineconescala.PineconeScalaClientException
+import io.cequence.pineconescala.service.PineconeInferenceServiceFactory.{
+  configPrefix,
+  loadTimeouts
+}
+import io.cequence.wsclient.ResponseImplicits.JsonSafeOps
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class PineconeAssistantServiceImpl(
+  apiKey: String,
+  explicitTimeouts: Option[Timeouts] = None
+)(
+  implicit val ec: ExecutionContext,
+  val materializer: Materializer
+) extends PineconeAssistantService
+    with WSRequestHelper {
+
+  override protected type PEP = EndPoint
+  override protected type PT = Tag
+  override val coreUrl: String = "https://api.pinecone.io/"
+  override protected val requestContext = WsRequestContext(
+    authHeaders = Seq(
+      ("Api-Key", apiKey),
+      ("X-Pinecone-API-Version", "2024-07")
+    ),
+    explTimeouts = explicitTimeouts
+  )
+
+  override def listAssistants(): Future[Seq[Assistant]] = {
+    execGET(EndPoint.assistants).map(_.asSafeJsonArray[Assistant])
+  }
+
+  override protected def handleErrorCodes(
+    httpCode: Int,
+    message: String
+  ): Nothing =
+    throw new PineconeScalaClientException(s"Code ${httpCode} : ${message}")
+
+}
+
+object PineconeAssistantServiceFactory extends PineconeServiceFactoryHelper {
+
+  def apply(
+    apiKey: String,
+    timeouts: Option[Timeouts] = None
+  )(
+    implicit ec: ExecutionContext,
+    materializer: Materializer
+  ): PineconeAssistantService = {
+    new PineconeAssistantServiceImpl(apiKey, timeouts)
+  }
+
+  def apply(
+    config: Config
+  )(
+    implicit ec: ExecutionContext,
+    materializer: Materializer
+  ): PineconeAssistantService = {
+    val timeouts = loadTimeouts(config)
+
+    apply(
+      apiKey = config.getString(s"$configPrefix.apiKey"),
+      timeouts = timeouts.toOption
+    )
+  }
+
+}

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -78,17 +78,23 @@ class PineconeAssistantServiceImpl(
 
   override def describeFile(
     assistantName: String,
-    fileName: String
+    fileId: UUID
   ): Future[Option[File]] =
     execGETRich(
       EndPoint.files,
       // FIXME: provide support for multiple end point params
-      endPointParam = Some(s"$assistantName/$fileName"),
+      endPointParam = Some(s"$assistantName/${fileId.toString}"),
     ).map { response =>
       handleNotFoundAndError(response).map(
         _.asSafeJson[File]
       )
     }
+
+  override def deleteFile(assistantName: String, fileId: UUID): Future[DeleteResponse] =
+    execDELETERich(
+      EndPoint.files,
+      endPointParam = Some(s"$assistantName/${fileId.toString}")
+    ).map(handleDeleteResponse)
 
   override protected def handleErrorCodes(
     httpCode: Int,

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -53,6 +53,17 @@ class PineconeAssistantServiceImpl(
     ).map(_.asSafeJson[Assistant])
   }
 
+
+  override def describeAssistant(name: String): Future[Option[Assistant]] =
+    execGETRich(
+      EndPoint.assistants,
+      endPointParam = Some(name)
+    ).map { response =>
+      handleNotFoundAndError(response).map(
+        _.asSafeJson[Assistant]
+      )
+    }
+
   override protected def handleErrorCodes(
     httpCode: Int,
     message: String

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -2,7 +2,7 @@ package io.cequence.pineconescala.service
 
 import akka.stream.Materializer
 import com.typesafe.config.Config
-import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, File, ListAssistantsResponse, ListFilesResponse}
+import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, ListAssistantsResponse, ListFilesResponse}
 import io.cequence.wsclient.domain.{RichResponse, WsRequestContext}
 import io.cequence.wsclient.service.ws.{Timeouts, WSRequestHelper}
 import io.cequence.pineconescala.JsonFormats._

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -2,10 +2,9 @@ package io.cequence.pineconescala.service
 
 import akka.stream.Materializer
 import com.typesafe.config.Config
-import io.cequence.pineconescala.domain.response.{Assistant, DeleteResponse}
+import io.cequence.pineconescala.domain.response.{Assistant, DeleteResponse, File}
 import io.cequence.wsclient.domain.{RichResponse, WsRequestContext}
 import io.cequence.wsclient.service.ws.{Timeouts, WSRequestHelper}
-import play.api.libs.ws.StandaloneWSRequest
 import io.cequence.pineconescala.JsonFormats._
 import io.cequence.pineconescala.PineconeScalaClientException
 import io.cequence.pineconescala.service.PineconeInferenceServiceFactory.{
@@ -76,6 +75,20 @@ class PineconeAssistantServiceImpl(
       endPointParam = Some(assistantName)
     ).map(_.asSafeJson[File])
   }
+
+  override def describeFile(
+    assistantName: String,
+    fileName: String
+  ): Future[Option[File]] =
+    execGETRich(
+      EndPoint.files,
+      // FIXME: provide support for multiple end point params
+      endPointParam = Some(s"$assistantName/$fileName"),
+    ).map { response =>
+      handleNotFoundAndError(response).map(
+        _.asSafeJson[File]
+      )
+    }
 
   override protected def handleErrorCodes(
     httpCode: Int,

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -2,7 +2,7 @@ package io.cequence.pineconescala.service
 
 import akka.stream.Materializer
 import com.typesafe.config.Config
-import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, File, ListAssistantsResponse}
+import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, File, ListAssistantsResponse, ListFilesResponse}
 import io.cequence.wsclient.domain.{RichResponse, WsRequestContext}
 import io.cequence.wsclient.service.ws.{Timeouts, WSRequestHelper}
 import io.cequence.pineconescala.JsonFormats._
@@ -35,9 +35,8 @@ class PineconeAssistantServiceImpl(
     explTimeouts = explicitTimeouts
   )
 
-  override def listAssistants(): Future[Seq[Assistant]] = {
+  override def listAssistants(): Future[Seq[Assistant]] =
     execGET(EndPoint.assistants).map(_.asSafeJson[ListAssistantsResponse]).map(_.assistants)
-  }
 
   override def createAssistant(
     name: String,
@@ -67,6 +66,9 @@ class PineconeAssistantServiceImpl(
       EndPoint.assistants,
       endPointParam = Some(name)
     ).map(handleDeleteResponse)
+
+  override def listFiles(assistantName: String): Future[Seq[File]] =
+    execGET(EndPoint.files, endPointParam = Some(assistantName)).map(_.asSafeJson[ListFilesResponse]).map(_.files)
 
   override def uploadFile(assistantName: String): Future[File] = {
     // TODO: file contents

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -2,7 +2,7 @@ package io.cequence.pineconescala.service
 
 import akka.stream.Materializer
 import com.typesafe.config.Config
-import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, File}
+import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, File, ListAssistantsResponse}
 import io.cequence.wsclient.domain.{RichResponse, WsRequestContext}
 import io.cequence.wsclient.service.ws.{Timeouts, WSRequestHelper}
 import io.cequence.pineconescala.JsonFormats._
@@ -36,7 +36,7 @@ class PineconeAssistantServiceImpl(
   )
 
   override def listAssistants(): Future[Seq[Assistant]] = {
-    execGET(EndPoint.assistants).map(_.asSafeJsonArray[Assistant])
+    execGET(EndPoint.assistants).map(_.asSafeJson[ListAssistantsResponse]).map(_.assistants)
   }
 
   override def createAssistant(

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -27,7 +27,7 @@ class PineconeAssistantServiceImpl(
   override protected val requestContext = WsRequestContext(
     authHeaders = Seq(
       ("Api-Key", apiKey),
-     // ("X-Pinecone-API-Version", "2024-07")
+      ("X-Pinecone-API-Version", "2024-07")
     ),
     explTimeouts = explicitTimeouts
   )

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -69,6 +69,14 @@ class PineconeAssistantServiceImpl(
       endPointParam = Some(name)
     ).map(handleDeleteResponse)
 
+  override def uploadFile(assistantName: String): Future[File] = {
+    // TODO: file contents
+    execPOST(
+      EndPoint.files,
+      endPointParam = Some(assistantName)
+    ).map(_.asSafeJson[File])
+  }
+
   override protected def handleErrorCodes(
     httpCode: Int,
     message: String

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -40,6 +40,19 @@ class PineconeAssistantServiceImpl(
     execGET(EndPoint.assistants).map(_.asSafeJsonArray[Assistant])
   }
 
+  override def createAssistant(
+    name: String,
+    metadata: Map[String, String]
+  ): Future[Assistant] = {
+    execPOST(
+      EndPoint.assistants,
+      bodyParams = jsonBodyParams(
+        Tag.name -> Some(name),
+        Tag.metadata -> Some(metadata)
+      )
+    ).map(_.asSafeJson[Assistant])
+  }
+
   override protected def handleErrorCodes(
     httpCode: Int,
     message: String

--- a/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
+++ b/pinecone-client/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImpl.scala
@@ -7,12 +7,9 @@ import io.cequence.wsclient.domain.{RichResponse, WsRequestContext}
 import io.cequence.wsclient.service.ws.{Timeouts, WSRequestHelper}
 import io.cequence.pineconescala.JsonFormats._
 import io.cequence.pineconescala.PineconeScalaClientException
-import io.cequence.pineconescala.service.PineconeInferenceServiceFactory.{configPrefix, loadTimeouts}
-import io.cequence.wsclient.JsonUtil.toJson
 import io.cequence.wsclient.ResponseImplicits.JsonSafeOps
 import play.api.libs.json.Json
 
-import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 class PineconeAssistantServiceImpl(
@@ -30,7 +27,7 @@ class PineconeAssistantServiceImpl(
   override protected val requestContext = WsRequestContext(
     authHeaders = Seq(
       ("Api-Key", apiKey),
-      ("X-Pinecone-API-Version", "2024-07")
+     // ("X-Pinecone-API-Version", "2024-07")
     ),
     explTimeouts = explicitTimeouts
   )
@@ -65,37 +62,6 @@ class PineconeAssistantServiceImpl(
     execDELETERich(
       EndPoint.assistants,
       endPointParam = Some(name)
-    ).map(handleDeleteResponse)
-
-  override def listFiles(assistantName: String): Future[Seq[File]] =
-    execGET(EndPoint.files, endPointParam = Some(assistantName)).map(_.asSafeJson[ListFilesResponse]).map(_.files)
-
-  override def uploadFile(assistantName: String): Future[File] = {
-    // TODO: file contents
-    execPOST(
-      EndPoint.files,
-      endPointParam = Some(assistantName)
-    ).map(_.asSafeJson[File])
-  }
-
-  override def describeFile(
-    assistantName: String,
-    fileId: UUID
-  ): Future[Option[File]] =
-    execGETRich(
-      EndPoint.files,
-      // FIXME: provide support for multiple end point params
-      endPointParam = Some(s"$assistantName/${fileId.toString}"),
-    ).map { response =>
-      handleNotFoundAndError(response).map(
-        _.asSafeJson[File]
-      )
-    }
-
-  override def deleteFile(assistantName: String, fileId: UUID): Future[DeleteResponse] =
-    execDELETERich(
-      EndPoint.files,
-      endPointParam = Some(s"$assistantName/${fileId.toString}")
     ).map(handleDeleteResponse)
 
   override def chatWithAssistant(assistantName: String, messages: Seq[String]): Future[ChatCompletionResponse] =

--- a/pinecone-client/src/test/resources/assistant-input-file.txt
+++ b/pinecone-client/src/test/resources/assistant-input-file.txt
@@ -1,0 +1,1 @@
+The quick brown fox jumped over the lazy dog

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/ChatCompletionCodecSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/ChatCompletionCodecSpec.scala
@@ -14,15 +14,18 @@ class ChatCompletionCodecSpec extends AnyFlatSpec with Matchers {
   val chatCompletionResponseJson = """
     |{
     |  "id" : "00000000000000006f3994cbaacfe3fa",
-    |  "choices" : [ {
-    |    "finish_reason" : "stop",
-    |    "index" : 0,
-    |    "message" : {
-    |      "role" : "assistant",
-    |    }
-    |      "content" : "Based on the provided search results, there is no information available regarding the maximum height of a red pine. The search result only contains a sentence about a fox and a dog, which is unrelated to the question about red pines  [1].\n\nReferences:\n1. [pinecone-assistant.txt](https://storage.googleapis.com/knowledge-prod-files/549946b9-cc33-45e2-97bd-bf9e5d9ba17b%2Fdefa42cb-7409-4ecc-89b9-367045b4e6e8%2F60a9e195-1025-427b-8520-5f834b5614fc.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=ke-prod-1%40pc-knowledge-prod.iam.gserviceaccount.com%2F20240713%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240713T131700Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=inline&response-content-type=text%2Fplain&X-Goog-Signature=3205693609e40c6389efe27d111ca7cae3a327e3344152fd4e96d1e70d11bdc328b4d4add6af4a67517595474ccaee9b5a555f0be6b8583043ddff8961902ff894c7fa6a54c74471d3b55e5c19680f3fdc71ebd62721c9a7fff08eeeb1491a733094ee3642adf90537ce37c7664a9c84559342ade3d9e59e1b3fb6a7e7b740308d439da5f7f0715e877a3f75075bef77aa0106ad708479105fc6f0530474a50cf0aaa8c661c7672513d40a2b015076a200dd08ce9383a1d8de21cfa144debe8af1f720f10cdbc8c177345c9e35fec8a715850832ddcde235d90f628fe9fb08ac5b0da1fea201be9058631eec46e089c0e9652ca85584c3d63248c5daf5d08780) \n"
-    |  } ],
-    |  "model" : "testAssistant"
+    |  "choices" : [
+    |    {
+    |      "finish_reason" : "stop",
+    |      "index" : 0,
+    |      "message" : {
+    |        "role" : "assistant",
+    |        "content" : "Some response from the assistant"
+    |      }
+    |   }
+    |  ],
+    |  "model" : "test-assistant"
+    |}
     |""".stripMargin
 
   "decoder for chat completions" should "decode a chat completion response" in {
@@ -33,7 +36,7 @@ class ChatCompletionCodecSpec extends AnyFlatSpec with Matchers {
         Choice(
           FinishReason.Stop,
           index = 0,
-          message = ChatCompletionMessage(role = Choice.Role.assistant, content = "Based on the provided search results, there is no information available regarding the maximum height of a red pine. The search result only contains a sentence about a fox and a dog, which is unrelated to the question about red pines  [1].\n\nReferences:\n1. [pinecone-assistant.txt](https://storage.googleapis.com/knowledge-prod-files/549946b9-cc33-45e2-97bd-bf9e5d9ba17b%2Fdefa42cb-7409-4ecc-89b9-367045b4e6e8%2F60a9e195-1025-427b-8520-5f834b5614fc.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=ke-prod-1%40pc-knowledge-prod.iam.gserviceaccount.com%2F20240713%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240713T131700Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=inline&response-content-type=text%2Fplain&X-Goog-Signature=3205693609e40c6389efe27d111ca7cae3a327e3344152fd4e96d1e70d11bdc328b4d4add6af4a67517595474ccaee9b5a555f0be6b8583043ddff8961902ff894c7fa6a54c74471d3b55e5c19680f3fdc71ebd62721c9a7fff08eeeb1491a733094ee3642adf90537ce37c7664a9c84559342ade3d9e59e1b3fb6a7e7b740308d439da5f7f0715e877a3f75075bef77aa0106ad708479105fc6f0530474a50cf0aaa8c661c7672513d40a2b015076a200dd08ce9383a1d8de21cfa144debe8af1f720f10cdbc8c177345c9e35fec8a715850832ddcde235d90f628fe9fb08ac5b0da1fea201be9058631eec46e089c0e9652ca85584c3d63248c5daf5d08780) \n")
+          message = ChatCompletionMessage(role = Choice.Role.assistant, content = "Some response from the assistant")
         )
       )
     )

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/ChatCompletionCodecSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/ChatCompletionCodecSpec.scala
@@ -1,0 +1,44 @@
+package io.cequence.pineconescala.service
+
+import io.cequence.pineconescala.domain.response.Choice.{ChatCompletionMessage, FinishReason}
+import io.cequence.pineconescala.domain.response.{ChatCompletionResponse, Choice}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import play.api.libs.json.Json
+
+class ChatCompletionCodecSpec extends AnyFlatSpec with Matchers {
+
+  import io.cequence.pineconescala.JsonFormats._
+
+  val chatCompletionResponseJson = """
+    |{
+    |  "id" : "00000000000000006f3994cbaacfe3fa",
+    |  "choices" : [ {
+    |    "finish_reason" : "stop",
+    |    "index" : 0,
+    |    "message" : {
+    |      "role" : "assistant",
+    |    }
+    |      "content" : "Based on the provided search results, there is no information available regarding the maximum height of a red pine. The search result only contains a sentence about a fox and a dog, which is unrelated to the question about red pines  [1].\n\nReferences:\n1. [pinecone-assistant.txt](https://storage.googleapis.com/knowledge-prod-files/549946b9-cc33-45e2-97bd-bf9e5d9ba17b%2Fdefa42cb-7409-4ecc-89b9-367045b4e6e8%2F60a9e195-1025-427b-8520-5f834b5614fc.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=ke-prod-1%40pc-knowledge-prod.iam.gserviceaccount.com%2F20240713%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240713T131700Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=inline&response-content-type=text%2Fplain&X-Goog-Signature=3205693609e40c6389efe27d111ca7cae3a327e3344152fd4e96d1e70d11bdc328b4d4add6af4a67517595474ccaee9b5a555f0be6b8583043ddff8961902ff894c7fa6a54c74471d3b55e5c19680f3fdc71ebd62721c9a7fff08eeeb1491a733094ee3642adf90537ce37c7664a9c84559342ade3d9e59e1b3fb6a7e7b740308d439da5f7f0715e877a3f75075bef77aa0106ad708479105fc6f0530474a50cf0aaa8c661c7672513d40a2b015076a200dd08ce9383a1d8de21cfa144debe8af1f720f10cdbc8c177345c9e35fec8a715850832ddcde235d90f628fe9fb08ac5b0da1fea201be9058631eec46e089c0e9652ca85584c3d63248c5daf5d08780) \n"
+    |  } ],
+    |  "model" : "testAssistant"
+    |""".stripMargin
+
+  "decoder for chat completions" should "decode a chat completion response" in {
+    val chatCompletionChoices = ChatCompletionResponse(
+      id = "00000000000000006f3994cbaacfe3fa",
+      model = "test-assistant",
+      choices = Seq(
+        Choice(
+          FinishReason.Stop,
+          index = 0,
+          message = ChatCompletionMessage(role = Choice.Role.assistant, content = "Based on the provided search results, there is no information available regarding the maximum height of a red pine. The search result only contains a sentence about a fox and a dog, which is unrelated to the question about red pines  [1].\n\nReferences:\n1. [pinecone-assistant.txt](https://storage.googleapis.com/knowledge-prod-files/549946b9-cc33-45e2-97bd-bf9e5d9ba17b%2Fdefa42cb-7409-4ecc-89b9-367045b4e6e8%2F60a9e195-1025-427b-8520-5f834b5614fc.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=ke-prod-1%40pc-knowledge-prod.iam.gserviceaccount.com%2F20240713%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240713T131700Z&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&response-content-disposition=inline&response-content-type=text%2Fplain&X-Goog-Signature=3205693609e40c6389efe27d111ca7cae3a327e3344152fd4e96d1e70d11bdc328b4d4add6af4a67517595474ccaee9b5a555f0be6b8583043ddff8961902ff894c7fa6a54c74471d3b55e5c19680f3fdc71ebd62721c9a7fff08eeeb1491a733094ee3642adf90537ce37c7664a9c84559342ade3d9e59e1b3fb6a7e7b740308d439da5f7f0715e877a3f75075bef77aa0106ad708479105fc6f0530474a50cf0aaa8c661c7672513d40a2b015076a200dd08ce9383a1d8de21cfa144debe8af1f720f10cdbc8c177345c9e35fec8a715850832ddcde235d90f628fe9fb08ac5b0da1fea201be9058631eec46e089c0e9652ca85584c3d63248c5daf5d08780) \n")
+        )
+      )
+    )
+
+    Json.parse(chatCompletionResponseJson).as[ChatCompletionResponse] shouldBe chatCompletionChoices
+  }
+
+}

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantFileServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantFileServiceImplSpec.scala
@@ -2,10 +2,8 @@ package io.cequence.pineconescala.service
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import akka.stream.scaladsl.Source
 import com.typesafe.config.{Config, ConfigFactory}
 import io.cequence.pineconescala.domain.response.Assistant.Status.Ready
-import io.cequence.pineconescala.domain.response.FileResponse.Status.{Deleting, Processing}
 import io.cequence.pineconescala.domain.response.{Assistant, DeleteResponse, FileResponse}
 import org.scalatest.concurrent.Eventually.{PatienceConfig, eventually}
 import org.scalatest.matchers.must.Matchers
@@ -14,10 +12,9 @@ import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatest.{BeforeAndAfterEach, GivenWhenThen, OptionValues}
 
-import java.io.{File, PrintWriter}
+import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
-import java.util.UUID
 import scala.concurrent.ExecutionContext
 
 class PineconeAssistantFileServiceImplSpec
@@ -56,11 +53,12 @@ class PineconeAssistantFileServiceImplSpec
 
   "Pinecone Assistant File Service" when {
 
-    "list files" in {
+/*    "list files" in {
       val assistantService = assistantServiceBuilder
       val assistantFileService = assistantFileServiceBuilder
       val assistantFile = createAssistantFile()
       for {
+        // TODO: extract creating and tear down to an operator similar to 'in' for ensuring fixtures
         _ <- assistantService.createAssistant(assistantName, parameters)
         _ <- eventuallyAssistantIs(Ready)(assistantService, assistantName)
         beforeCreateFiles <- assistantFileService.listFiles(assistantName)
@@ -71,7 +69,7 @@ class PineconeAssistantFileServiceImplSpec
         beforeCreateFiles.size should be(0)
         afterCreateFiles.size should be(1)
       }
-    }
+    }*/
 
     "upload file" in {
       val assistantService = assistantServiceBuilder
@@ -79,6 +77,7 @@ class PineconeAssistantFileServiceImplSpec
       val assistantFile = createAssistantFile()
       for {
         _ <- assistantService.createAssistant(assistantName, parameters)
+        _ <- eventuallyAssistantIs(Ready)(assistantService, assistantName)
         assistantFile <- assistantFileService.uploadFile(assistantFile, Some("input-file"), assistantName)
         _ <- tearDown(assistantService)
       } yield {
@@ -86,7 +85,7 @@ class PineconeAssistantFileServiceImplSpec
       }
     }
 
-    "describe file" in {
+/*    "describe file" in {
       val assistantService = assistantServiceBuilder
       val assistantFileService = assistantFileServiceBuilder
       val assistantFile = createAssistantFile()
@@ -110,8 +109,8 @@ class PineconeAssistantFileServiceImplSpec
       val assistantFileService = assistantFileServiceBuilder
       val assistantFile = createAssistantFile()
       for {
-         _ <- assistantService.createAssistant(assistantName, parameters)
-         _ <- eventuallyAssistantIs(Ready)(assistantService, assistantName)
+        _ <- assistantService.createAssistant(assistantName, parameters)
+        _ <- eventuallyAssistantIs(Ready)(assistantService, assistantName)
         uploadedFile <- assistantFileService.uploadFile(assistantFile, Some("input-file"), assistantName)
         beforeDelete <- assistantFileService.describeFile(assistantName, uploadedFile.id)
         deleteResponse <- assistantFileService.deleteFile(assistantName, uploadedFile.id)
@@ -138,6 +137,22 @@ class PineconeAssistantFileServiceImplSpec
         deleteResponse should be(DeleteResponse.NotFound)
       }
     }
+
+
+    "chat with assistant" in {
+      val assistantService = assistantServiceBuilder
+      val assistantFileService = assistantFileServiceBuilder
+      val messages = Seq("What is the maximum height of a red pine?")
+      for {
+        _ <- assistantService.createAssistant(assistantName, parameters)
+        _ <- eventuallyAssert(() => assistantService.listAssistants())(_.size == 1)
+        chatResponse <- assistantFileService.chatWithAssistant(assistantName, messages)
+        _ <- tearDown(assistantService)
+      } yield {
+        chatResponse.model shouldBe assistantName
+        chatResponse.choices.size should be > 0
+      }
+    }*/
 
   }
 

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantFileServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantFileServiceImplSpec.scala
@@ -1,0 +1,123 @@
+package io.cequence.pineconescala.service
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.concurrent.Eventually.{PatienceConfig, eventually}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatest.{BeforeAndAfterEach, GivenWhenThen, OptionValues}
+
+import scala.concurrent.ExecutionContext
+
+class PineconeAssistantFileServiceImplSpec
+    extends AsyncWordSpec
+    with GivenWhenThen
+    with ServerlessFixtures
+    with Matchers
+    with PineconeServiceConsts
+    with BeforeAndAfterEach
+    with OptionValues {
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+  implicit val materializer: Materializer = Materializer(ActorSystem())
+
+  val serverlessConfig: Config = ConfigFactory.load("serverless.conf")
+
+  private val assistantName = "testAssistant"
+  private val parameters = Map("key" -> "value")
+
+  def assistantServiceBuilder: PineconeAssistantService =
+    PineconeAssistantServiceFactory(serverlessConfig)
+
+  def assistantFileServiceBuilder: PineconeAssistantFileService =
+    PineconeAssistantFileServiceFactory(serverlessConfig)
+
+  private def tearDown(service: PineconeAssistantService) = {
+    implicit val patienceConfig: PatienceConfig =
+      PatienceConfig(timeout = 10.seconds, interval = 100.millis)
+    service.deleteAssistant(assistantName).flatMap { _ =>
+      eventually {
+        val deletedF = service.describeAssistant(assistantName)
+        deletedF.map(_ should be(None))
+      }
+    }
+  }
+
+  "Pinecone Assistant File Service" when {
+
+    "list files" in {
+      val assistantService = assistantServiceBuilder
+      val assistantFileService = assistantFileServiceBuilder
+      for {
+        _ <- assistantService.createAssistant(assistantName, parameters)
+        beforeCreateFiles <- assistantFileService.listFiles(assistantName)
+        _ <- assistantFileService.uploadFile(assistantName)
+        afterCreateFiles <- assistantFileService.listFiles(assistantName)
+        _ <- tearDown(assistantService)
+      } yield {
+        //assert(true)
+        beforeCreateFiles.size should be(0)
+        afterCreateFiles.size should be(1)
+      }
+    }
+//
+//    "upload file" in {
+//      val service = assistantServiceBuilder
+//      for {
+//        _ <- service.createAssistant(assistantName, parameters)
+//        file <- service.uploadFile(assistantName)
+//        _ <- tearDown(service)
+//      } yield {
+//        // TODO: assert file contents
+//        assert(true)
+//      }
+//    }
+//
+//    "describe file" in {
+//      val service = assistantServiceBuilder
+//      for {
+//        _ <- service.createAssistant(assistantName, parameters)
+//        file <- service.uploadFile(assistantName)
+//        maybeDescribedFile <- service.describeFile(assistantName, file.id)
+//        _ <- tearDown(service)
+//      } yield {
+//        val describedFile = maybeDescribedFile.value
+//        describedFile.name shouldBe file.name
+//        describedFile.id shouldBe file.id
+//        describedFile.created_on shouldBe file.created_on
+//        describedFile.updated_on shouldBe file.updated_on
+//        describedFile.metadata shouldBe file.metadata
+//      }
+//    }
+
+//    "delete an existing file" in {
+//      val service = assistantServiceBuilder
+//      for {
+//        _ <- service.createAssistant(assistantName, parameters)
+//        //file <- service.uploadFile(assistantName)
+//        //beforeDelete <- service.describeFile(assistantName, file.id)
+//        deleteResponse <- service.deleteFile(assistantName, file.id)
+//        afterDelete <- service.describeFile(assistantName, file.id)
+//        _ <- tearDown(service)
+//      } yield {
+//        beforeDelete should not be empty
+//        deleteResponse should be(DeleteResponse.Deleted)
+//        afterDelete shouldBe empty
+//      }
+//    }
+
+//    "return NotFound when deleting a non-existent file" in {
+//      val service = assistantServiceBuilder
+//      for {
+//        deleteResponse <- service.deleteFile(assistantName, java.util.UUID.randomUUID())
+//      } yield {
+//        deleteResponse should be(DeleteResponse.NotFound)
+//      }
+//    }
+
+  }
+
+}

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantFileServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantFileServiceImplSpec.scala
@@ -2,7 +2,11 @@ package io.cequence.pineconescala.service
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
+import akka.stream.scaladsl.Source
 import com.typesafe.config.{Config, ConfigFactory}
+import io.cequence.pineconescala.domain.response.Assistant.Status.Ready
+import io.cequence.pineconescala.domain.response.FileResponse.Status.{Deleting, Processing}
+import io.cequence.pineconescala.domain.response.{Assistant, DeleteResponse, FileResponse}
 import org.scalatest.concurrent.Eventually.{PatienceConfig, eventually}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
@@ -10,6 +14,10 @@ import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatest.{BeforeAndAfterEach, GivenWhenThen, OptionValues}
 
+import java.io.{File, PrintWriter}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import java.util.UUID
 import scala.concurrent.ExecutionContext
 
 class PineconeAssistantFileServiceImplSpec
@@ -19,10 +27,12 @@ class PineconeAssistantFileServiceImplSpec
     with Matchers
     with PineconeServiceConsts
     with BeforeAndAfterEach
+    with EventuallyAssert
     with OptionValues {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
   implicit val materializer: Materializer = Materializer(ActorSystem())
+  implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 10.seconds, interval = 100.millis)
 
   val serverlessConfig: Config = ConfigFactory.load("serverless.conf")
 
@@ -36,8 +46,6 @@ class PineconeAssistantFileServiceImplSpec
     PineconeAssistantFileServiceFactory(serverlessConfig)
 
   private def tearDown(service: PineconeAssistantService) = {
-    implicit val patienceConfig: PatienceConfig =
-      PatienceConfig(timeout = 10.seconds, interval = 100.millis)
     service.deleteAssistant(assistantName).flatMap { _ =>
       eventually {
         val deletedF = service.describeAssistant(assistantName)
@@ -51,73 +59,97 @@ class PineconeAssistantFileServiceImplSpec
     "list files" in {
       val assistantService = assistantServiceBuilder
       val assistantFileService = assistantFileServiceBuilder
+      val assistantFile = createAssistantFile()
       for {
         _ <- assistantService.createAssistant(assistantName, parameters)
+        _ <- eventuallyAssistantIs(Ready)(assistantService, assistantName)
         beforeCreateFiles <- assistantFileService.listFiles(assistantName)
-        _ <- assistantFileService.uploadFile(assistantName)
+        _ <- assistantFileService.uploadFile(assistantFile, Some("input-file"), assistantName)
         afterCreateFiles <- assistantFileService.listFiles(assistantName)
         _ <- tearDown(assistantService)
       } yield {
-        //assert(true)
         beforeCreateFiles.size should be(0)
         afterCreateFiles.size should be(1)
       }
     }
-//
-//    "upload file" in {
-//      val service = assistantServiceBuilder
-//      for {
-//        _ <- service.createAssistant(assistantName, parameters)
-//        file <- service.uploadFile(assistantName)
-//        _ <- tearDown(service)
-//      } yield {
-//        // TODO: assert file contents
-//        assert(true)
-//      }
-//    }
-//
-//    "describe file" in {
-//      val service = assistantServiceBuilder
-//      for {
-//        _ <- service.createAssistant(assistantName, parameters)
-//        file <- service.uploadFile(assistantName)
-//        maybeDescribedFile <- service.describeFile(assistantName, file.id)
-//        _ <- tearDown(service)
-//      } yield {
-//        val describedFile = maybeDescribedFile.value
-//        describedFile.name shouldBe file.name
-//        describedFile.id shouldBe file.id
-//        describedFile.created_on shouldBe file.created_on
-//        describedFile.updated_on shouldBe file.updated_on
-//        describedFile.metadata shouldBe file.metadata
-//      }
-//    }
 
-//    "delete an existing file" in {
-//      val service = assistantServiceBuilder
-//      for {
-//        _ <- service.createAssistant(assistantName, parameters)
-//        //file <- service.uploadFile(assistantName)
-//        //beforeDelete <- service.describeFile(assistantName, file.id)
-//        deleteResponse <- service.deleteFile(assistantName, file.id)
-//        afterDelete <- service.describeFile(assistantName, file.id)
-//        _ <- tearDown(service)
-//      } yield {
-//        beforeDelete should not be empty
-//        deleteResponse should be(DeleteResponse.Deleted)
-//        afterDelete shouldBe empty
-//      }
-//    }
+    "upload file" in {
+      val assistantService = assistantServiceBuilder
+      val assistantFileService = assistantFileServiceBuilder
+      val assistantFile = createAssistantFile()
+      for {
+        _ <- assistantService.createAssistant(assistantName, parameters)
+        assistantFile <- assistantFileService.uploadFile(assistantFile, Some("input-file"), assistantName)
+        _ <- tearDown(assistantService)
+      } yield {
+        assistantFile.status shouldBe FileResponse.Status.Processing
+      }
+    }
 
-//    "return NotFound when deleting a non-existent file" in {
-//      val service = assistantServiceBuilder
-//      for {
-//        deleteResponse <- service.deleteFile(assistantName, java.util.UUID.randomUUID())
-//      } yield {
-//        deleteResponse should be(DeleteResponse.NotFound)
-//      }
-//    }
+    "describe file" in {
+      val assistantService = assistantServiceBuilder
+      val assistantFileService = assistantFileServiceBuilder
+      val assistantFile = createAssistantFile()
+      for {
+        _ <- assistantService.createAssistant(assistantName, parameters)
+        file <- assistantFileService.uploadFile(assistantFile, Some("input-file"), assistantName)
+        maybeDescribedFile <- assistantFileService.describeFile(assistantName, file.id)
+        _ <- tearDown(assistantService)
+      } yield {
+        val describedFile = maybeDescribedFile.value
+        describedFile.name shouldBe file.name
+        describedFile.id shouldBe file.id
+        describedFile.created_on shouldBe file.created_on
+        describedFile.updated_on shouldBe file.updated_on
+        describedFile.metadata shouldBe file.metadata
+      }
+    }
 
+    "delete an existing file" in {
+      val assistantService = assistantServiceBuilder
+      val assistantFileService = assistantFileServiceBuilder
+      val assistantFile = createAssistantFile()
+      for {
+         _ <- assistantService.createAssistant(assistantName, parameters)
+         _ <- eventuallyAssistantIs(Ready)(assistantService, assistantName)
+        uploadedFile <- assistantFileService.uploadFile(assistantFile, Some("input-file"), assistantName)
+        beforeDelete <- assistantFileService.describeFile(assistantName, uploadedFile.id)
+        deleteResponse <- assistantFileService.deleteFile(assistantName, uploadedFile.id)
+        afterDelete <- assistantFileService.describeFile(assistantName, uploadedFile.id)
+        _ <- tearDown(assistantService)
+      } yield {
+        beforeDelete should not be empty
+        deleteResponse should be(DeleteResponse.Deleted)
+        afterDelete.value.status shouldBe FileResponse.Status.Deleting
+        assert(true)
+      }
+    }
+
+    "return NotFound when deleting a non-existent file" in {
+      val assistantService = assistantServiceBuilder
+      val assistantFileService = assistantFileServiceBuilder
+
+      for {
+        _ <- assistantService.createAssistant(assistantName, parameters)
+        _ <- eventuallyAssistantIs(Ready)(assistantService, assistantName)
+        deleteResponse <- assistantFileService.deleteFile(assistantName, java.util.UUID.randomUUID())
+        _ <- tearDown(assistantService)
+      } yield {
+        deleteResponse should be(DeleteResponse.NotFound)
+      }
+    }
+
+  }
+
+  private def eventuallyAssistantIs(status: Assistant.Status)(assistantService: PineconeAssistantService, assistantName: String) = {
+    eventuallyAssert(() => assistantService.describeAssistant(assistantName))(_.exists(_.hasStatus(status)))
+  }
+
+  private def createAssistantFile(): File = {
+    val path = "pinecone-assistant.txt"
+    Files.write(Paths.get(path), "The quick brown fox jumps over the lazy dog.".getBytes(StandardCharsets.UTF_8))
+    val inputFile = Paths.get(path).toFile
+    inputFile
   }
 
 }

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
@@ -3,6 +3,7 @@ package io.cequence.pineconescala.service
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.typesafe.config.{Config, ConfigFactory}
+import io.cequence.pineconescala.domain.response.DeleteResponse
 import org.scalatest.GivenWhenThen
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
@@ -61,6 +62,27 @@ class PineconeAssistantServiceImplSpec
       } yield {
         assistant.get.name should be("test-assistant")
         assistant.get.metadata should be(Map("key" -> "value"))
+      }
+    }
+
+    "delete an existing assistant" in {
+      val service = assistantServiceBuilder
+      for {
+        _ <- service.createAssistant("test-assistant", Map("key" -> "value"))
+        deleteResponse <- service.deleteAssistant("test-assistant")
+        afterDelete <- service.describeAssistant("test-assistant")
+      } yield {
+        deleteResponse should be(DeleteResponse.Deleted)
+        afterDelete should be(None)
+      }
+
+      "return NotFound when deleting a non-existent assistant" in {
+        val service = assistantServiceBuilder
+        for {
+          deleteResponse <- service.deleteAssistant("non-existent-assistant")
+        } yield {
+          deleteResponse should be(DeleteResponse.NotFound)
+        }
       }
     }
 

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
@@ -23,6 +23,7 @@ class PineconeAssistantServiceImplSpec
     with Matchers
     with PineconeServiceConsts
     with BeforeAndAfterEach
+    with EventuallyAssert
     with OptionValues {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
@@ -43,12 +44,6 @@ class PineconeAssistantServiceImplSpec
       eventuallyAssert(() => service.describeAssistant(assistantName))(_.isEmpty)
     }
   }
-
-  private def eventuallyAssert[A](f: () => Future[A])(check: A => Boolean)
-                                 (implicit config: PatienceConfig): Future[Assertion] =
-    eventually {
-      f().map(a => assert(check(a)))
-    }
 
   "Pinecone Assistant Service" when {
 

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
@@ -44,6 +44,26 @@ class PineconeAssistantServiceImplSpec
       }
     }
 
+    "return None when describing a non-existent assistant" in {
+      val service = assistantServiceBuilder
+      for {
+        assistant <- service.describeAssistant("non-existent-assistant")
+      } yield {
+        assistant should be(None)
+      }
+    }
+
+    "return assistant when describing an existing assistant" in {
+      val service = assistantServiceBuilder
+      for {
+        _ <- service.createAssistant("test-assistant", Map("key" -> "value"))
+        assistant <- service.describeAssistant("test-assistant")
+      } yield {
+        assistant.get.name should be("test-assistant")
+        assistant.get.metadata should be(Map("key" -> "value"))
+      }
+    }
+
   }
 
 }

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
@@ -5,16 +5,14 @@ import akka.stream.Materializer
 import com.typesafe.config.{Config, ConfigFactory}
 import io.cequence.pineconescala.domain.response.Assistant.Status.Terminating
 import io.cequence.pineconescala.domain.response.DeleteResponse
-import org.scalatest.{Assertion, BeforeAndAfterEach, GivenWhenThen, OptionValues}
-import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.{BeforeAndAfterEach, GivenWhenThen, OptionValues}
 import org.scalatest.concurrent.Eventually.PatienceConfig
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.scalatest.wordspec.AsyncWordSpec
 
-import scala.Console.println
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class PineconeAssistantServiceImplSpec
     extends AsyncWordSpec
@@ -53,13 +51,12 @@ class PineconeAssistantServiceImplSpec
     "list assistants" in {
       val service = assistantServiceBuilder
       for {
-        beforeCreateAssistants <- service.listAssistants()
+        beforeCreateAssistant <- service.listAssistants()
         _ <- service.createAssistant(assistantName, parameters)
         _ <- eventuallyAssert(() => service.listAssistants())(_.size == 1)
         _ <- tearDown(service)
       } yield {
-        beforeCreateAssistants.size should be(0)
-        // afterCreateAssistants.size should be(1)
+        beforeCreateAssistant.size should be(0)
       }
     }
 

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
@@ -12,9 +12,11 @@ import org.scalatest.wordspec.AsyncWordSpec
 import scala.concurrent.ExecutionContext
 
 class PineconeAssistantServiceImplSpec
-  extends AsyncWordSpec
-  with GivenWhenThen
-  with ServerlessFixtures with Matchers with PineconeServiceConsts {
+    extends AsyncWordSpec
+    with GivenWhenThen
+    with ServerlessFixtures
+    with Matchers
+    with PineconeServiceConsts {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
   implicit val materializer: Materializer = Materializer(ActorSystem())
@@ -75,14 +77,14 @@ class PineconeAssistantServiceImplSpec
         deleteResponse should be(DeleteResponse.Deleted)
         afterDelete should be(None)
       }
+    }
 
-      "return NotFound when deleting a non-existent assistant" in {
-        val service = assistantServiceBuilder
-        for {
-          deleteResponse <- service.deleteAssistant("non-existent-assistant")
-        } yield {
-          deleteResponse should be(DeleteResponse.NotFound)
-        }
+    "return NotFound when deleting a non-existent assistant" in {
+      val service = assistantServiceBuilder
+      for {
+        deleteResponse <- service.deleteAssistant("non-existent-assistant")
+      } yield {
+        deleteResponse should be(DeleteResponse.NotFound)
       }
     }
 

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
@@ -1,0 +1,39 @@
+package io.cequence.pineconescala.service
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.GivenWhenThen
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.ExecutionContext
+
+class PineconeAssistantServiceImplSpec
+  extends AsyncWordSpec
+  with GivenWhenThen
+  with ServerlessFixtures with Matchers with PineconeServiceConsts {
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+  implicit val materializer: Materializer = Materializer(ActorSystem())
+
+  val serverlessConfig: Config = ConfigFactory.load("serverless.conf")
+
+  def assistantServiceBuilder: PineconeAssistantService =
+    PineconeAssistantServiceFactory(serverlessConfig)
+
+  "Pinecone Assistant Service" when {
+
+    "list assistants" in {
+      val service = assistantServiceBuilder
+      for {
+        assistants <- service.listAssistants()
+      } yield {
+        assistants.size should be(0)
+      }
+    }
+
+  }
+
+}

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
@@ -34,6 +34,16 @@ class PineconeAssistantServiceImplSpec
       }
     }
 
+    "create assistant" in {
+      val service = assistantServiceBuilder
+      for {
+        assistant <- service.createAssistant("test-assistant", Map("key" -> "value"))
+      } yield {
+        assistant.name should be("test-assistant")
+        assistant.metadata should be(Map("key" -> "value"))
+      }
+    }
+
   }
 
 }

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/PineconeAssistantServiceImplSpec.scala
@@ -3,8 +3,9 @@ package io.cequence.pineconescala.service
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.typesafe.config.{Config, ConfigFactory}
+import io.cequence.pineconescala.domain.response.Assistant.Status.Terminating
 import io.cequence.pineconescala.domain.response.DeleteResponse
-import org.scalatest.{BeforeAndAfterEach, GivenWhenThen}
+import org.scalatest.{Assertion, BeforeAndAfterEach, GivenWhenThen, OptionValues}
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.Eventually.PatienceConfig
 import org.scalatest.matchers.must.Matchers
@@ -12,44 +13,58 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.scalatest.wordspec.AsyncWordSpec
 
-import scala.concurrent.ExecutionContext
+import scala.Console.println
+import scala.concurrent.{ExecutionContext, Future}
 
 class PineconeAssistantServiceImplSpec
     extends AsyncWordSpec
     with GivenWhenThen
     with ServerlessFixtures
     with Matchers
-    with PineconeServiceConsts with BeforeAndAfterEach {
+    with PineconeServiceConsts
+    with BeforeAndAfterEach
+    with OptionValues {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
   implicit val materializer: Materializer = Materializer(ActorSystem())
 
   val serverlessConfig: Config = ConfigFactory.load("serverless.conf")
 
-  private val assistantName = "test-assistant"
+  private val assistantName = "testAssistant"
   private val parameters = Map("key" -> "value")
 
   def assistantServiceBuilder: PineconeAssistantService =
     PineconeAssistantServiceFactory(serverlessConfig)
 
   private def tearDown(service: PineconeAssistantService) = {
-    implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 10.seconds, interval = 100.millis)
+    implicit val patienceConfig: PatienceConfig =
+      PatienceConfig(timeout = 10.seconds, interval = 100.millis)
     service.deleteAssistant(assistantName).flatMap { _ =>
-      eventually {
-        val deletedF = service.describeAssistant(assistantName)
-        deletedF.map(_ should be (None))
-      }
+      eventuallyAssert(() => service.describeAssistant(assistantName))(_.isEmpty)
     }
   }
 
+  private def eventuallyAssert[A](f: () => Future[A])(check: A => Boolean)
+                                 (implicit config: PatienceConfig): Future[Assertion] =
+    eventually {
+      f().map(a => assert(check(a)))
+    }
+
   "Pinecone Assistant Service" when {
+
+    implicit val patienceConfig: PatienceConfig =
+      PatienceConfig(timeout = 10.seconds, interval = 100.millis)
 
     "list assistants" in {
       val service = assistantServiceBuilder
       for {
-        assistants <- service.listAssistants()
+        beforeCreateAssistants <- service.listAssistants()
+        _ <- service.createAssistant(assistantName, parameters)
+        _ <- eventuallyAssert(() => service.listAssistants())(_.size == 1)
+        _ <- tearDown(service)
       } yield {
-        assistants.size should be(0)
+        beforeCreateAssistants.size should be(0)
+        // afterCreateAssistants.size should be(1)
       }
     }
 
@@ -57,10 +72,13 @@ class PineconeAssistantServiceImplSpec
       val service = assistantServiceBuilder
       for {
         assistant <- service.createAssistant(assistantName, parameters)
+        createdAssistant <- service.describeAssistant(assistantName)
         _ <- tearDown(service)
       } yield {
         assistant.name should be(assistantName)
         assistant.metadata should be(parameters)
+        createdAssistant.value.name should be(assistantName)
+        createdAssistant.value.metadata should be(parameters)
       }
     }
 
@@ -85,14 +103,18 @@ class PineconeAssistantServiceImplSpec
       }
     }
 
-    "delete an existing assistant" in {
+    "delete an existing assistant eventually, marking it firstly as Terminating when listing assistants" in {
       val service = assistantServiceBuilder
       for {
         _ <- service.createAssistant(assistantName, parameters)
         deleteResponse <- service.deleteAssistant(assistantName)
+        afterDelete <- service.listAssistants()
+        _ <- eventuallyAssert(() => service.listAssistants())(_.isEmpty)
         _ <- tearDown(service)
-      } yield
-        deleteResponse should be(DeleteResponse.Deleted)
+      } yield {
+        deleteResponse shouldBe DeleteResponse.Deleted
+        afterDelete(0).status shouldBe Terminating
+      }
     }
 
     "return NotFound when deleting a non-existent assistant" in {
@@ -105,5 +127,4 @@ class PineconeAssistantServiceImplSpec
     }
 
   }
-
 }

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/ServerlessPineconeInferenceServiceImplSpec.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/ServerlessPineconeInferenceServiceImplSpec.scala
@@ -3,12 +3,12 @@ package io.cequence.pineconescala.service
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.GivenWhenThen
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.wordspec.AsyncWordSpec
-import org.scalatest.GivenWhenThen
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class ServerlessPineconeInferenceServiceImplSpec
     extends AsyncWordSpec

--- a/pinecone-client/src/test/scala/io/cequence/pineconescala/service/package.scala
+++ b/pinecone-client/src/test/scala/io/cequence/pineconescala/service/package.scala
@@ -1,0 +1,20 @@
+package io.cequence.pineconescala
+
+import org.scalatest.{Assertion, AsyncTestSuite}
+import org.scalatest.concurrent.Eventually.{eventually, PatienceConfig}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+package object service {
+
+  trait EventuallyAssert { this: AsyncTestSuite =>
+
+    def eventuallyAssert[A](f: () => Future[A])(check: A => Boolean)
+                           (implicit config: PatienceConfig): Future[Assertion] =
+      eventually {
+        f().map(a => assert(check(a)))
+      }
+
+  }
+
+}

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/Assistant.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/Assistant.scala
@@ -5,7 +5,13 @@ import io.cequence.wsclient.domain.EnumValue
 import java.time.OffsetDateTime
 
 final case class Assistant(name: String, metadata: Map[String, String] = Map.empty, status: Assistant.Status,
-                           created_on: Option[OffsetDateTime], updated_on: Option[OffsetDateTime])
+                           created_on: Option[OffsetDateTime], updated_on: Option[OffsetDateTime]) {
+  def hasFailed: Boolean = hasStatus(Assistant.Status.Failed)
+  def isInitializing: Boolean = hasStatus(Assistant.Status.Initializing)
+  def isReady: Boolean = hasStatus(Assistant.Status.Ready)
+  def isTerminating: Boolean = hasStatus(Assistant.Status.Terminating)
+  def hasStatus(status: Assistant.Status): Boolean = this.status == status
+}
 
 object Assistant {
 

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/Assistant.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/Assistant.scala
@@ -25,3 +25,5 @@ object Assistant {
   }
 
 }
+
+final case class UserMessage(content: String)

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/Assistant.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/Assistant.scala
@@ -1,0 +1,21 @@
+package io.cequence.pineconescala.domain.response
+
+import io.cequence.wsclient.domain.EnumValue
+
+import java.time.OffsetDateTime
+
+final case class Assistant(name: String, metadata: Map[String, String] = Map.empty, status: Assistant.Status,
+                           created_on: Option[OffsetDateTime], updated_on: Option[OffsetDateTime])
+
+object Assistant {
+
+  sealed trait Status extends EnumValue
+
+  object Status {
+    case object Initializing extends Status
+    case object Failed extends Status
+    case object Ready extends Status
+    case object Terminating extends Status
+  }
+
+}

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/ChatCompletionResponse.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/ChatCompletionResponse.scala
@@ -1,17 +1,9 @@
 package io.cequence.pineconescala.domain.response
 
 import io.cequence.pineconescala.domain.response.Choice.{ChatCompletionMessage, FinishReason}
+import io.cequence.wsclient.domain.{EnumValue, NamedEnumValue}
 
-/**
- * @param id
- * @param model
- *   The name of the assistant returning the response.
- */
-final case class ChatCompletionResponse(
-  id: String,
-  model: String,
-  messages: Seq[Choice]
-)
+final case class ChatCompletionResponse(id: String, model: String, choices: Seq[Choice])
 
 final case class Choice(
   finish_reason: FinishReason,
@@ -22,9 +14,9 @@ final case class Choice(
 object Choice {
   final case class ChatCompletionMessage(role: Role, content: String)
 
-  sealed trait FinishReason
+  sealed trait FinishReason extends EnumValue
   object FinishReason {
-    case object Stop extends FinishReason
+    case object Stop extends NamedEnumValue("stop") with FinishReason
     case object Length extends FinishReason
     case object ToolCalls extends FinishReason
     case object ContentFilter extends FinishReason

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/ChatCompletionResponse.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/ChatCompletionResponse.scala
@@ -1,0 +1,39 @@
+package io.cequence.pineconescala.domain.response
+
+import io.cequence.pineconescala.domain.response.Choice.{ChatCompletionMessage, FinishReason}
+
+/**
+ * @param id
+ * @param model
+ *   The name of the assistant returning the response.
+ */
+final case class ChatCompletionResponse(
+  id: String,
+  model: String,
+  messages: Seq[Choice]
+)
+
+final case class Choice(
+  finish_reason: FinishReason,
+  index: Int,
+  message: ChatCompletionMessage
+)
+
+object Choice {
+  final case class ChatCompletionMessage(role: Role, content: String)
+
+  sealed trait FinishReason
+  object FinishReason {
+    case object Stop extends FinishReason
+    case object Length extends FinishReason
+    case object ToolCalls extends FinishReason
+    case object ContentFilter extends FinishReason
+    case object FunctionCall extends FinishReason
+  }
+
+  sealed trait Role
+  object Role {
+    case object user extends Role
+    case object assistant extends Role
+  }
+}

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/File.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/File.scala
@@ -1,0 +1,21 @@
+package io.cequence.pineconescala.domain.response
+
+import io.cequence.wsclient.domain.EnumValue
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+final case class File(name: String, id: UUID, metadata: Map[String, String] = Map.empty, created_on: Option[OffsetDateTime], updated_on: Option[OffsetDateTime])
+
+object File {
+
+  sealed trait Status extends EnumValue
+
+  object Status {
+    case object Processing extends Status
+    case object Available extends Status
+    case object Deleting extends Status
+    case object ProcessingFailed extends Status
+  }
+
+}

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/FileResponse.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/FileResponse.scala
@@ -5,9 +5,9 @@ import io.cequence.wsclient.domain.EnumValue
 import java.time.OffsetDateTime
 import java.util.UUID
 
-final case class File(name: String, id: UUID, metadata: Map[String, String] = Map.empty, created_on: Option[OffsetDateTime], updated_on: Option[OffsetDateTime])
+final case class FileResponse(name: String, id: UUID, metadata: Map[String, String] = Map.empty, created_on: Option[OffsetDateTime], updated_on: Option[OffsetDateTime])
 
-object File {
+object FileResponse {
 
   sealed trait Status extends EnumValue
 

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/FileResponse.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/FileResponse.scala
@@ -5,7 +5,13 @@ import io.cequence.wsclient.domain.EnumValue
 import java.time.OffsetDateTime
 import java.util.UUID
 
-final case class FileResponse(name: String, id: UUID, metadata: Map[String, String] = Map.empty, created_on: Option[OffsetDateTime], updated_on: Option[OffsetDateTime])
+final case class FileResponse(name: String, id: UUID, metadata: Map[String, String] = Map.empty, created_on: Option[OffsetDateTime], updated_on: Option[OffsetDateTime], status: FileResponse.Status) {
+  def isProcessing: Boolean = hasStatus(FileResponse.Status.Processing)
+  def isAvailable: Boolean = hasStatus(FileResponse.Status.Available)
+  def isDeleting: Boolean = hasStatus(FileResponse.Status.Deleting)
+  def hasProcessingFailed: Boolean = hasStatus(FileResponse.Status.ProcessingFailed)
+  def hasStatus(status: FileResponse.Status): Boolean = this.status == status
+}
 
 object FileResponse {
 

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/ListAssistantsResponse.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/ListAssistantsResponse.scala
@@ -1,0 +1,3 @@
+package io.cequence.pineconescala.domain.response
+
+final case class ListAssistantsResponse(assistants: List[Assistant])

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/ListFilesResponse.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/ListFilesResponse.scala
@@ -1,3 +1,3 @@
 package io.cequence.pineconescala.domain.response
 
-final case class ListFilesResponse(files: List[File])
+final case class ListFilesResponse(files: List[FileResponse])

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/ListFilesResponse.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/domain/response/ListFilesResponse.scala
@@ -1,0 +1,3 @@
+package io.cequence.pineconescala.domain.response
+
+final case class ListFilesResponse(files: List[File])

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantFileService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantFileService.scala
@@ -1,7 +1,8 @@
 package io.cequence.pineconescala.service
 
-import io.cequence.pineconescala.domain.response.{DeleteResponse, File}
+import io.cequence.pineconescala.domain.response.{DeleteResponse, FileResponse}
 
+import java.io.File
 import java.util.UUID
 import scala.concurrent.Future
 
@@ -13,23 +14,25 @@ trait PineconeAssistantFileService {
    * @param assistantName The name of the assistant to get files of.
    * @return
    */
-  def listFiles(assistantName: String): Future[Seq[File]]
+  def listFiles(assistantName: String): Future[Seq[FileResponse]]
 
   /**
    * This operation uploads a file to a specified assistant.
    *
-   * @param name The name of the base to upload files to.
+   * @param file A file to upload.
+   * @param displayFileName The name of the file to be displayed.
+   * @param name The name of the assistant to upload file to.
    * @return
    */
-  def uploadFile(assistantName: String): Future[File]
+  def uploadFile(file: File, displayFileName: Option[String], assistantName: String): Future[FileResponse]
 
   /**
    *
-   * @param assistantName The name of the base to get file from.
+   * @param assistantName The name of the assistant to get file from.
    * @param fileId The UUID of the file to be described.
    * @return
    */
-  def describeFile(assistantName: String, fileId: UUID): Future[Option[File]]
+  def describeFile(assistantName: String, fileId: UUID): Future[Option[FileResponse]]
 
   /**
    *

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantFileService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantFileService.scala
@@ -1,6 +1,6 @@
 package io.cequence.pineconescala.service
 
-import io.cequence.pineconescala.domain.response.{DeleteResponse, FileResponse}
+import io.cequence.pineconescala.domain.response.{ChatCompletionResponse, DeleteResponse, FileResponse}
 
 import java.io.File
 import java.util.UUID
@@ -41,5 +41,16 @@ trait PineconeAssistantFileService {
    * @return
    */
   def deleteFile(assistantName: String, fileId: UUID): Future[DeleteResponse]
+
+
+  /**
+   * This operation queries the completions endpoint of a Pinecone Assistant.
+   * For guidance and examples, see the chat with assistant guide.
+   *
+   * @param assistantName The name of the assistant to be described.
+   * @param messages An array of objects that represent the messages in a conversation.
+   * @return The ChatCompletionModel describes the response format of a chat request
+   */
+  def chatWithAssistant(assistantName: String, messages: Seq[String]): Future[ChatCompletionResponse]
 
 }

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantFileService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantFileService.scala
@@ -1,0 +1,42 @@
+package io.cequence.pineconescala.service
+
+import io.cequence.pineconescala.domain.response.{DeleteResponse, File}
+
+import java.util.UUID
+import scala.concurrent.Future
+
+trait PineconeAssistantFileService {
+
+  /**
+   * This operation returns a list of all files in an assistant.
+   *
+   * @param assistantName The name of the assistant to get files of.
+   * @return
+   */
+  def listFiles(assistantName: String): Future[Seq[File]]
+
+  /**
+   * This operation uploads a file to a specified assistant.
+   *
+   * @param name The name of the base to upload files to.
+   * @return
+   */
+  def uploadFile(assistantName: String): Future[File]
+
+  /**
+   *
+   * @param assistantName The name of the base to get file from.
+   * @param fileId The UUID of the file to be described.
+   * @return
+   */
+  def describeFile(assistantName: String, fileId: UUID): Future[Option[File]]
+
+  /**
+   *
+   * @param assistantName
+   * @param fileId The UUID of the file to be described.
+   * @return
+   */
+  def deleteFile(assistantName: String, fileId: UUID): Future[DeleteResponse]
+
+}

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -42,14 +42,4 @@ trait PineconeAssistantService extends CloseableService with PineconeServiceCons
    */
   def deleteAssistant(name: String): Future[DeleteResponse]
 
-  /**
-   * This operation queries the completions endpoint of a Pinecone Assistant.
-   * For guidance and examples, see the chat with assistant guide.
-   *
-   * @param assistantName The name of the assistant to be described.
-   * @param messages An array of objects that represent the messages in a conversation.
-   * @return The ChatCompletionModel describes the response format of a chat request
-   */
-  def chatWithAssistant(assistantName: String, messages: Seq[String]): Future[ChatCompletionResponse]
-
 }

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -1,6 +1,6 @@
 package io.cequence.pineconescala.service
 
-import io.cequence.pineconescala.domain.response.Assistant
+import io.cequence.pineconescala.domain.response.{Assistant, DeleteResponse}
 import io.cequence.wsclient.service.CloseableService
 
 import scala.concurrent.Future
@@ -32,5 +32,13 @@ trait PineconeAssistantService extends CloseableService with PineconeServiceCons
    * @return
    */
   def describeAssistant(name: String): Future[Option[Assistant]]
+
+  /**
+   * This operation deletes an existing assistant.
+   *
+   * @param name The name of the base to delete.
+   * @return
+   */
+  def deleteAssistant(name: String): Future[DeleteResponse]
 
 }

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -1,6 +1,6 @@
 package io.cequence.pineconescala.service
 
-import io.cequence.pineconescala.domain.response.{Assistant, DeleteResponse}
+import io.cequence.pineconescala.domain.response.{Assistant, DeleteResponse, File}
 import io.cequence.wsclient.service.CloseableService
 
 import scala.concurrent.Future
@@ -40,5 +40,14 @@ trait PineconeAssistantService extends CloseableService with PineconeServiceCons
    * @return
    */
   def deleteAssistant(name: String): Future[DeleteResponse]
+
+  /**
+   * This operation uploads a file to a specified assistant.
+   *
+   * @param name The name of the base to upload files to.
+   * @return
+   */
+  def uploadFile(assistantName: String): Future[File]
+
 
 }

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -1,6 +1,6 @@
 package io.cequence.pineconescala.service
 
-import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, File}
+import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, FileResponse}
 import io.cequence.wsclient.service.CloseableService
 
 import java.util.UUID

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -18,10 +18,19 @@ trait PineconeAssistantService extends CloseableService with PineconeServiceCons
    * This operation deploys a Pinecone Assistant. This is where you specify the underlying training model,
    * which cloud provider you would like to deploy with, and more.
    *
-   * @param name
-   * @param metadata
+   * @param name The name of the assistant. Resource name must be 1-45 characters long, start and end with
+   *             an alphanumeric character, and consist only of lower case alphanumeric characters or '-'.
+   * @param metadata A dictionary containing metadata for the assistant.
    * @return
    */
   def createAssistant(name: String, metadata: Map[String, String]): Future[Assistant]
+
+  /**
+   * This operation describes an assistant and its metadata.
+   *
+   * @param name The name of the assistant to poll.
+   * @return
+   */
+  def describeAssistant(name: String): Future[Option[Assistant]]
 
 }

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -1,6 +1,6 @@
 package io.cequence.pineconescala.service
 
-import io.cequence.pineconescala.domain.response.{Assistant, DeleteResponse, File}
+import io.cequence.pineconescala.domain.response.{Assistant, ChatCompletionResponse, DeleteResponse, File}
 import io.cequence.wsclient.service.CloseableService
 
 import java.util.UUID
@@ -65,5 +65,15 @@ trait PineconeAssistantService extends CloseableService with PineconeServiceCons
    * @return
    */
   def deleteFile(assistantName: String, fileId: UUID): Future[DeleteResponse]
+
+  /**
+   * This operation queries the completions endpoint of a Pinecone Assistant.
+   * For guidance and examples, see the chat with assistant guide.
+   *
+   * @param assistantName The name of the assistant to be described.
+   * @param messages An array of objects that represent the messages in a conversation.
+   * @return The ChatCompletionModel describes the response format of a chat request
+   */
+  def chatWithAssistant(assistantName: String, messages: Seq[String]): Future[ChatCompletionResponse]
 
 }

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -1,0 +1,17 @@
+package io.cequence.pineconescala.service
+
+import io.cequence.pineconescala.domain.response.Assistant
+import io.cequence.wsclient.service.CloseableService
+
+import scala.concurrent.Future
+
+trait PineconeAssistantService extends CloseableService with PineconeServiceConsts {
+
+  /**
+   * This operation returns a list of all assistants in a project.
+   *
+   * @return
+   */
+  def listAssistants(): Future[Seq[Assistant]]
+
+}

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -3,6 +3,7 @@ package io.cequence.pineconescala.service
 import io.cequence.pineconescala.domain.response.{Assistant, DeleteResponse, File}
 import io.cequence.wsclient.service.CloseableService
 
+import java.util.UUID
 import scala.concurrent.Future
 
 trait PineconeAssistantService extends CloseableService with PineconeServiceConsts {
@@ -49,13 +50,20 @@ trait PineconeAssistantService extends CloseableService with PineconeServiceCons
    */
   def uploadFile(assistantName: String): Future[File]
 
-
   /**
    *
    * @param assistantName The name of the base to get file from.
-   * @param fileName The UUID of the file to be described.
+   * @param fileId The UUID of the file to be described.
    * @return
    */
-  def describeFile(assistantName: String, fileName: String): Future[Option[File]]
+  def describeFile(assistantName: String, fileId: UUID): Future[Option[File]]
+
+  /**
+   *
+   * @param assistantName
+   * @param fileId The UUID of the file to be described.
+   * @return
+   */
+  def deleteFile(assistantName: String, fileId: UUID): Future[DeleteResponse]
 
 }

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -50,4 +50,12 @@ trait PineconeAssistantService extends CloseableService with PineconeServiceCons
   def uploadFile(assistantName: String): Future[File]
 
 
+  /**
+   *
+   * @param assistantName The name of the base to get file from.
+   * @param fileName The UUID of the file to be described.
+   * @return
+   */
+  def describeFile(assistantName: String, fileName: String): Future[Option[File]]
+
 }

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -43,38 +43,6 @@ trait PineconeAssistantService extends CloseableService with PineconeServiceCons
   def deleteAssistant(name: String): Future[DeleteResponse]
 
   /**
-   * This operation returns a list of all files in an assistant.
-   *
-   * @param assistantName The name of the assistant to get files of.
-   * @return
-   */
-  def listFiles(assistantName: String): Future[Seq[File]]
-
-  /**
-   * This operation uploads a file to a specified assistant.
-   *
-   * @param name The name of the base to upload files to.
-   * @return
-   */
-  def uploadFile(assistantName: String): Future[File]
-
-  /**
-   *
-   * @param assistantName The name of the base to get file from.
-   * @param fileId The UUID of the file to be described.
-   * @return
-   */
-  def describeFile(assistantName: String, fileId: UUID): Future[Option[File]]
-
-  /**
-   *
-   * @param assistantName
-   * @param fileId The UUID of the file to be described.
-   * @return
-   */
-  def deleteFile(assistantName: String, fileId: UUID): Future[DeleteResponse]
-
-  /**
    * This operation queries the completions endpoint of a Pinecone Assistant.
    * For guidance and examples, see the chat with assistant guide.
    *

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -43,6 +43,14 @@ trait PineconeAssistantService extends CloseableService with PineconeServiceCons
   def deleteAssistant(name: String): Future[DeleteResponse]
 
   /**
+   * This operation returns a list of all files in an assistant.
+   *
+   * @param assistantName The name of the assistant to get files of.
+   * @return
+   */
+  def listFiles(assistantName: String): Future[Seq[File]]
+
+  /**
    * This operation uploads a file to a specified assistant.
    *
    * @param name The name of the base to upload files to.

--- a/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
+++ b/pinecone-core/src/main/scala/io/cequence/pineconescala/service/PineconeAssistantService.scala
@@ -14,4 +14,14 @@ trait PineconeAssistantService extends CloseableService with PineconeServiceCons
    */
   def listAssistants(): Future[Seq[Assistant]]
 
+  /**
+   * This operation deploys a Pinecone Assistant. This is where you specify the underlying training model,
+   * which cloud provider you would like to deploy with, and more.
+   *
+   * @param name
+   * @param metadata
+   * @return
+   */
+  def createAssistant(name: String, metadata: Map[String, String]): Future[Assistant]
+
 }


### PR DESCRIPTION
Integrate with Pinecone's Assistant API. This is implemented by two services (as they have hit different Pinecone service URLs):
- assistant service - 4 methods - creating, listing, describing, and deleting of assistants
- assistant file service - 5 methods - creating, listing, describing, and deleting of assistant's files + chat completion

**ToDo**
Uploading of files fails with:
`Code 400 : {"error":{"code":"INVALID_ARGUMENT","message":"Invalid file type for upload"},"status":400}`
It succeeds via curl when uploading content of a `txt` file.

**Problems**
Even though the API returns 200 on assistant delete, the assistant is not deleted immediately but it happens eventually which seems to violate an HTTP protocol.
File response status Stop is serialized as "stop" in violation of the API spec.

I expect there will be similar issues.

**Potential Improvements**
Extract maintenance of fixtures to an operator similar to spec's `in` which would create the Fixture and tear it down.